### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A small UI library built with Jetpack compose that contains the NeoPOP design st
 
 
 ## How to Install?
-1. Open your Project's settings.grale file.
+1. Open your Project's settings.gradle file.
 2. Add the following...
 ```
 dependencyResolutionManagement {


### PR DESCRIPTION
Corrected a typo in the README file:
Changed `settings.grale` to `settings.gradle` to reference the correct Gradle settings file.